### PR TITLE
Initialize counters for gdpr-only runs

### DIFF
--- a/reddit_stash.py
+++ b/reddit_stash.py
@@ -32,6 +32,12 @@ def main():
 
     # Load the log file
     file_log = load_file_log(save_directory)
+
+    # Initialize counters for processed statistics
+    total_processed = 0
+    total_skipped = 0
+    total_size = 0
+
     # Process API accessible items
     if process_api:
         print("Processing items from Reddit API...")


### PR DESCRIPTION
## Summary
- initialize `total_processed`, `total_skipped` and `total_size` before the API and GDPR blocks

## Testing
- `python -m py_compile reddit_stash.py dropbox_utils.py utils/*.py`


------
https://chatgpt.com/codex/tasks/task_e_684196057e1483218b0c9223411bf50a