### PR TITLE
feat: Add option to ignore TLS errors for third-party content

### DIFF
--- a/README.md
+++ b/README.md
@@ -547,10 +547,11 @@ The `settings.ini` file in the root directory of the project allows you to confi
 save_directory = reddit/ # your system save directory
 dropbox_directory = /reddit # your dropbox directory
 save_type = ALL  # Options: 'ALL' to save all activity, 'SAVED' to save only saved posts/comments, 'ACTIVITY' to save only the users posts and comments, 'UPVOTED' to save users upvoted post and comments
-check_type = LOG # Options: 'LOG' to use the logging file to verify the file exisitnece, 'DIR' to verify the file exisitence based on the downloaded directory. 
+check_type = LOG # Options: 'LOG' to use the logging file to verify the file exisitnece, 'DIR' to verify the file exisitence based on the downloaded directory.
 unsave_after_download = false
 process_gdpr = false # Whether to process GDPR export data
 process_api = true # Whether to process items from Reddit API (default: true)
+ignore_tls_errors = false # Whether to ignore TLS certificate errors for third-party content (use with caution)
 
 [Configuration]
 client_id = None  # Can be set here or via environment variables
@@ -574,6 +575,7 @@ password = None  # Can be set here or via environment variables
 * **unsave_after_download**: When set to `true`, automatically unsaves posts after downloading them (see notes below).
 * **process_gdpr**: When set to `true`, processes GDPR export data (explained in detail below).
 * **process_api**: When set to `true` (default), processes items from the Reddit API.
+* **ignore_tls_errors**: When set to `true`, ignores TLS certificate errors when downloading images from third-party sites. ⚠️ **Warning**: This reduces security by bypassing SSL certificate verification. Only enable for archival purposes when you explicitly need to download content from sites with expired or invalid certificates.
 
 Note: You can still use environment variables as a fallback or override for the Reddit API credentials if they are not set in the settings.ini file.
 

--- a/settings.ini
+++ b/settings.ini
@@ -6,6 +6,7 @@ check_type = LOG
 unsave_after_download = false
 process_gdpr = false
 process_api = true
+ignore_tls_errors = false
 
 [Configuration]
 client_id = None

--- a/utils/env_config.py
+++ b/utils/env_config.py
@@ -33,3 +33,21 @@ def load_config_and_env():
         raise Exception("One or more required credentials for Reddit API are missing.")
 
     return client_id, client_secret, username, password
+
+def get_ignore_tls_errors():
+    """Load the ignore_tls_errors setting from settings.ini."""
+    config_parser = configparser.ConfigParser()
+
+    # Dynamically determine the path to the root directory of the repository
+    BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+    # Construct the full path to the settings.ini file
+    config_file_path = os.path.join(BASE_DIR, 'settings.ini')
+
+    # Read the settings.ini file
+    config_parser.read(config_file_path)
+
+    # Get the ignore_tls_errors setting, default to False for security
+    ignore_tls_errors = config_parser.getboolean('Settings', 'ignore_tls_errors', fallback=False)
+
+    return ignore_tls_errors

--- a/utils/gdpr_processor.py
+++ b/utils/gdpr_processor.py
@@ -4,6 +4,7 @@ from tqdm import tqdm
 from utils.file_operations import save_to_file
 from utils.save_utils import save_submission, save_comment_and_context
 from utils.time_utilities import dynamic_sleep
+from utils.env_config import get_ignore_tls_errors
 
 def get_gdpr_directory(save_directory):
     """Return the path to the GDPR data directory."""
@@ -20,6 +21,9 @@ def process_gdpr_export(reddit, save_directory, existing_files, created_dirs_cac
     processed_count = 0
     skipped_count = 0
     total_size = 0
+
+    # Load the ignore_tls_errors setting
+    ignore_tls_errors = get_ignore_tls_errors()
     
     gdpr_dir = get_gdpr_directory(save_directory)
     
@@ -38,8 +42,9 @@ def process_gdpr_export(reddit, save_directory, existing_files, created_dirs_cac
                                        f"GDPR_POST_{submission.id}.md")
                 
                 # Use existing save_to_file function
-                if save_to_file(submission, file_path, save_submission, 
-                              existing_files, file_log, save_directory, created_dirs_cache):
+                if save_to_file(submission, file_path, save_submission,
+                              existing_files, file_log, save_directory, created_dirs_cache,
+                              ignore_tls_errors=ignore_tls_errors):
                     skipped_count += 1
                     continue
 
@@ -66,8 +71,9 @@ def process_gdpr_export(reddit, save_directory, existing_files, created_dirs_cac
                                        f"GDPR_COMMENT_{comment.id}.md")
                 
                 # Use existing save_to_file function
-                if save_to_file(comment, file_path, save_comment_and_context, 
-                              existing_files, file_log, save_directory, created_dirs_cache):
+                if save_to_file(comment, file_path, save_comment_and_context,
+                              existing_files, file_log, save_directory, created_dirs_cache,
+                              ignore_tls_errors=ignore_tls_errors):
                     skipped_count += 1
                     continue
 


### PR DESCRIPTION
- Added ignore_tls_errors setting to settings.ini (defaults to false)
- Implemented SSL bypass capability in download_image function
- Added configuration loading in env_config.py
- Pass TLS setting through all save functions in file_operations.py
- Updated GDPR processor to support TLS bypass
- Added documentation in README.md with security warnings

This allows archival of content from sites with expired certificates when explicitly enabled by the user. Addresses issue #2.