### PR TITLE
Add refresh-token auth, early-stop incremental fetch, and searchable HTML index

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,13 @@
 # Get these from https://www.reddit.com/prefs/apps
 REDDIT_CLIENT_ID=your_reddit_client_id_here
 REDDIT_CLIENT_SECRET=your_reddit_client_secret_here
+
+# Auth: choose ONE of the two options below.
+# Option 1 (preferred): a refresh token, so no password lives in your secrets.
+# Mint it once with: python get_refresh_token.py  (needs a "web app" Reddit app)
+# REDDIT_REFRESH_TOKEN=your_reddit_refresh_token_here
+#
+# Option 2: username + password (used only when REDDIT_REFRESH_TOKEN is unset).
 REDDIT_USERNAME=your_reddit_username
 REDDIT_PASSWORD=your_reddit_password
 

--- a/generate_index.py
+++ b/generate_index.py
@@ -1,0 +1,204 @@
+"""Build a single searchable index.html over an existing Reddit Stash backup.
+
+What it does for you: turn the folder of markdown files into one page you can
+open in any browser and type into to find a saved post, instead of grepping
+folders by hand. Why it matters: the backup is only as useful as your ability
+to find things in it, and this needs no server, no build step, and no network.
+How it works: walk the save directory, read the YAML front matter each markdown
+file already carries, and emit a self-contained index.html with a client-side
+filter box. Re-runnable any time (also against a synced Dropbox/S3 copy).
+
+    python generate_index.py               # uses save_directory from settings.ini
+    python generate_index.py reddit/       # explicit directory
+    python generate_index.py --selftest    # runnable check, no repo needed
+"""
+import os
+import sys
+import json
+import glob
+
+
+def _read_front_matter(md_path):
+    """Parse the flat `--- key: value ---` header + first `# title` line.
+
+    Returns a dict, or None if the file has no front matter block.
+    """
+    meta = {}
+    title = ""
+    try:
+        with open(md_path, "r", encoding="utf-8") as fh:
+            lines = fh.read().splitlines()
+    except (OSError, UnicodeDecodeError):
+        return None
+
+    if not lines or lines[0].strip() != "---":
+        return None
+
+    i = 1
+    while i < len(lines) and lines[i].strip() != "---":
+        key, sep, value = lines[i].partition(":")  # split on FIRST colon only
+        if sep:
+            meta[key.strip()] = value.strip()
+        i += 1
+
+    # First markdown heading after the front matter is the title.
+    for line in lines[i + 1:]:
+        if line.startswith("# "):
+            title = line[2:].strip()
+            break
+
+    meta["title"] = title
+    return meta
+
+
+def _category(filename):
+    """Coarse item type from the filename prefix Reddit Stash writes."""
+    name = filename.upper()
+    for prefix in ("SAVED_POST", "SAVED_COMMENT", "UPVOTE_POST", "UPVOTE_COMMENT",
+                   "GDPR_POST", "GDPR_COMMENT", "POST", "COMMENT"):
+        if name.startswith(prefix):
+            return prefix.replace("_", " ").title()
+    return "Item"
+
+
+def collect_items(save_directory):
+    """Walk the save directory and return one dict per markdown file."""
+    items = []
+    for md_path in glob.iglob(os.path.join(save_directory, "**", "*.md"), recursive=True):
+        meta = _read_front_matter(md_path)
+        if meta is None:
+            continue
+        rel = os.path.relpath(md_path, start=save_directory)
+        items.append({
+            "title": meta.get("title") or os.path.basename(md_path),
+            "subreddit": meta.get("subreddit", ""),
+            "author": meta.get("author", ""),
+            "timestamp": meta.get("timestamp", ""),
+            "flair": meta.get("flair", ""),
+            "permalink": meta.get("permalink", ""),
+            "category": _category(os.path.basename(md_path)),
+            "file": rel,
+        })
+    items.sort(key=lambda x: x["timestamp"], reverse=True)
+    return items
+
+
+# ponytail: data is injected as JSON and rendered via textContent in the browser,
+# so untrusted Reddit content can't inject markup. Only the </script> escape and
+# the http(s)-link guard below are needed.
+_PAGE = """<!DOCTYPE html>
+<html lang="en"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Reddit Stash Index</title>
+<style>
+  body{{font-family:system-ui,Arial,sans-serif;margin:0;background:#f6f7f8;color:#1a1a1b}}
+  header{{position:sticky;top:0;background:#ff4500;color:#fff;padding:12px 16px}}
+  header h1{{margin:0 0 8px;font-size:18px}}
+  #q{{width:100%;padding:10px;font-size:15px;border:none;border-radius:6px;box-sizing:border-box}}
+  #count{{padding:8px 16px;color:#666;font-size:13px}}
+  ul{{list-style:none;margin:0;padding:0 8px 40px}}
+  li{{background:#fff;margin:8px;padding:12px;border:1px solid #ddd;border-radius:6px}}
+  .t{{font-weight:600}}
+  .t a{{color:#1a1a1b;text-decoration:none}} .t a:hover{{color:#ff4500}}
+  .m{{color:#666;font-size:12px;margin-top:4px}}
+  .m a{{color:#0079d3;text-decoration:none}}
+  .b{{display:inline-block;background:#eef;border-radius:3px;padding:0 5px;font-size:11px;color:#334}}
+  @media(prefers-color-scheme:dark){{
+    body{{background:#0b0b0c;color:#d7dadc}} li{{background:#161617;border-color:#343536}}
+    .t a{{color:#d7dadc}} #q{{background:#161617;color:#d7dadc}} .b{{background:#22303c;color:#9fd}}
+  }}
+</style></head><body>
+<header><h1>Reddit Stash &mdash; {n} items</h1>
+<input id="q" placeholder="Filter by title, subreddit, author, flair, type&hellip;" autofocus></header>
+<div id="count"></div><ul id="list"></ul>
+<script>
+const DATA = {data};
+const list = document.getElementById('list'), count = document.getElementById('count');
+function render(items){{
+  list.textContent = '';
+  count.textContent = items.length + ' shown';
+  for (const it of items){{
+    const li = document.createElement('li');
+    const t = document.createElement('div'); t.className = 't';
+    const a = document.createElement('a'); a.textContent = it.title;
+    a.href = it.file; a.target = '_blank'; t.appendChild(a);
+    const m = document.createElement('div'); m.className = 'm';
+    const badge = document.createElement('span'); badge.className = 'b'; badge.textContent = it.category;
+    m.appendChild(badge);
+    m.appendChild(document.createTextNode(' ' + [it.subreddit, it.author, it.timestamp, it.flair].filter(Boolean).join(' \\u2022 ')));
+    if (/^https?:\\/\\//.test(it.permalink)){{
+      const p = document.createElement('a'); p.href = it.permalink; p.target = '_blank';
+      p.textContent = 'reddit'; m.appendChild(document.createTextNode(' \\u2022 ')); m.appendChild(p);
+    }}
+    li.appendChild(t); li.appendChild(m); list.appendChild(li);
+  }}
+}}
+document.getElementById('q').addEventListener('input', e => {{
+  const q = e.target.value.toLowerCase();
+  render(!q ? DATA : DATA.filter(it =>
+    (it.title+' '+it.subreddit+' '+it.author+' '+it.flair+' '+it.category).toLowerCase().includes(q)));
+}});
+render(DATA);
+</script></body></html>
+"""
+
+
+def build_html(items):
+    data = json.dumps(items, ensure_ascii=False).replace("</", "<\\/")  # keep </script> from closing the tag
+    return _PAGE.format(n=len(items), data=data)
+
+
+def main(argv):
+    args = [a for a in argv if not a.startswith("--")]
+    if args:
+        save_directory = args[0]
+    else:
+        import configparser
+        cp = configparser.ConfigParser()
+        cp.read("settings.ini")
+        save_directory = cp.get("Settings", "save_directory", fallback="reddit/")
+
+    if not os.path.isdir(save_directory):
+        print(f"Directory not found: {save_directory}")
+        return 1
+
+    items = collect_items(save_directory)
+    out = os.path.join(save_directory, "index.html")
+    with open(out, "w", encoding="utf-8") as fh:
+        fh.write(build_html(items))
+    print(f"Indexed {len(items)} items -> {out}")
+    return 0
+
+
+def _selftest():
+    import tempfile
+    with tempfile.TemporaryDirectory() as d:
+        os.makedirs(os.path.join(d, "apple"))
+        with open(os.path.join(d, "apple", "SAVED_POST_abc.md"), "w", encoding="utf-8") as fh:
+            fh.write("---\nid: abc\nsubreddit: /r/apple\ntimestamp: 2020-10-11 04:48:04\n"
+                     "author: /u/nstrm\npermalink: https://reddit.com/r/apple/comments/abc/x/\n---\n\n"
+                     "# A saved title with </script> and <b>markup</b>\n\nbody\n")
+        # a file with no front matter must be skipped
+        with open(os.path.join(d, "notes.md"), "w", encoding="utf-8") as fh:
+            fh.write("# just a note\n")
+
+        items = collect_items(d)
+        assert len(items) == 1, items
+        it = items[0]
+        assert it["title"] == "A saved title with </script> and <b>markup</b>"
+        assert it["subreddit"] == "/r/apple"
+        assert it["category"] == "Saved Post"
+        assert it["file"] == os.path.join("apple", "SAVED_POST_abc.md")
+
+        page = build_html(items)
+        assert "</script>" not in page.split("<\\/script>")[0].split("DATA = ")[1]  # data literal is escaped
+        assert "<b>markup</b>" not in page  # untrusted markup never lands as raw HTML
+        assert "A saved title" in page      # ...but the text is present (rendered via textContent)
+    print("selftest OK")
+
+
+if __name__ == "__main__":
+    if "--selftest" in sys.argv:
+        _selftest()
+    else:
+        sys.exit(main(sys.argv[1:]))

--- a/get_refresh_token.py
+++ b/get_refresh_token.py
@@ -1,0 +1,86 @@
+"""One-time helper: mint a Reddit refresh token for Reddit Stash.
+
+Why you'd want this: it lets you back up Reddit without putting your account
+PASSWORD in GitHub Actions secrets (or anywhere on a server). You authorize once
+in a browser, get a long-lived refresh token, and PRAW renews the short-lived
+access tokens for you from then on. What it does: walks the standard Reddit
+OAuth "web app" flow using PRAW (already a dependency) and prints the token.
+
+Requirements:
+  - A Reddit app of type "web app" (NOT "script") with redirect uri
+    http://localhost:8080 (set REDDIT_REDIRECT_URI to override).
+  - client_id / client_secret from https://www.reddit.com/prefs/apps
+
+Usage:
+  python get_refresh_token.py
+Then set the printed value as REDDIT_REFRESH_TOKEN (env var or settings.ini
+[Configuration] refresh_token). You can drop REDDIT_PASSWORD once this works.
+"""
+import os
+import sys
+
+import praw
+
+# Scopes Reddit Stash needs: identity (user.me), history (saved/upvoted lists),
+# read (fetch content), save (save/unsave). Matches what the backup actually calls.
+SCOPES = ["identity", "history", "read", "save"]
+STATE = "reddit-stash"
+
+
+def _extract_code(pasted, expected_state):
+    """Pull the ?code= value out of a pasted redirect URL, or accept a bare code."""
+    if "code=" in pasted:
+        from urllib.parse import urlparse, parse_qs
+        q = parse_qs(urlparse(pasted).query)
+        if expected_state and q.get("state", [None])[0] != expected_state:
+            raise ValueError("state mismatch - possible CSRF, aborting")
+        return q["code"][0].rstrip("#_")
+    return pasted.rstrip("#_")
+
+
+def main():
+    client_id = os.getenv("REDDIT_CLIENT_ID") or input("client_id: ").strip()
+    client_secret = os.getenv("REDDIT_CLIENT_SECRET") or input("client_secret: ").strip()
+    redirect_uri = os.getenv("REDDIT_REDIRECT_URI", "http://localhost:8080")
+
+    reddit = praw.Reddit(
+        client_id=client_id,
+        client_secret=client_secret,
+        redirect_uri=redirect_uri,
+        user_agent="reddit-stash token setup",
+    )
+
+    print("\n1. Open this URL, log in, and click 'Allow':\n")
+    print("   " + reddit.auth.url(scopes=SCOPES, state=STATE, duration="permanent") + "\n")
+    print("2. Your browser redirects to a localhost URL that fails to load - that's expected.")
+    print("   Copy the FULL address bar URL (or just the code= value) and paste it below.\n")
+
+    try:
+        code = _extract_code(input("redirected URL or code: ").strip(), STATE)
+        refresh_token = reddit.auth.authorize(code)
+    except Exception as e:
+        print(f"\n❌ Failed: {e}")
+        return 1
+
+    print("\n✅ Success. Set this as REDDIT_REFRESH_TOKEN:\n")
+    print("   " + refresh_token + "\n")
+    print("Verified as Reddit user:", reddit.user.me())
+    return 0
+
+
+def _selftest():
+    assert _extract_code("http://localhost:8080/?state=reddit-stash&code=ABC123#_", "reddit-stash") == "ABC123"
+    assert _extract_code("XYZ#_", None) == "XYZ"
+    try:
+        _extract_code("http://x/?state=bad&code=1", "reddit-stash")
+        assert False, "expected state mismatch to raise"
+    except ValueError:
+        pass
+    print("selftest OK")
+
+
+if __name__ == "__main__":
+    if "--selftest" in sys.argv:
+        _selftest()
+    else:
+        sys.exit(main())

--- a/reddit_stash.py
+++ b/reddit_stash.py
@@ -8,6 +8,22 @@ from utils.gdpr_processor import process_gdpr_export
 from utils.config_validator import validate_configuration
 from utils.feature_flags import get_feature_summary
 
+def _connect_reddit(client_id, client_secret, username, password, refresh_token):
+    """Build a PRAW client. Prefer refresh_token (no password in secrets, long-lived);
+    fall back to username+password."""
+    kwargs = {
+        'client_id': client_id,
+        'client_secret': client_secret,
+        'user_agent': f'Reddit Saved Saver by /u/{username or "reddit-stash"}',
+    }
+    if refresh_token:
+        kwargs['refresh_token'] = refresh_token
+    else:
+        kwargs['username'] = username
+        kwargs['password'] = password
+    return praw.Reddit(**kwargs)
+
+
 def main():
     # Validate configuration before proceeding
     print("Validating configuration...")
@@ -44,25 +60,11 @@ def main():
     # Initialize Reddit API connection (only if API processing is needed)
     reddit = None
     if process_api:
-        client_id, client_secret, username, password = load_config_and_env()
-        reddit = praw.Reddit(
-            client_id=client_id,
-            client_secret=client_secret,
-            username=username,
-            password=password,
-            user_agent=f'Reddit Saved Saver by /u/{username}'
-        )
+        reddit = _connect_reddit(*load_config_and_env())
     elif process_gdpr:
         # Try to load credentials for GDPR enrichment, but don't fail if missing
         try:
-            client_id, client_secret, username, password = load_config_and_env()
-            reddit = praw.Reddit(
-                client_id=client_id,
-                client_secret=client_secret,
-                username=username,
-                password=password,
-                user_agent=f'Reddit Saved Saver by /u/{username}'
-            )
+            reddit = _connect_reddit(*load_config_and_env())
         except Exception:
             print("No API credentials available. GDPR export will run in CSV-only mode.")
             reddit = None
@@ -113,6 +115,15 @@ def main():
     print(f"Markdown file storage: {total_size / (1024 * 1024):.2f} MB")
     print(f"Media file storage: {total_media_size / (1024 * 1024):.2f} MB")
     print(f"Total combined storage: {(total_size + total_media_size) / (1024 * 1024):.2f} MB")
+
+    # Build a browsable/searchable index.html over the backup. Best-effort:
+    # indexing must never fail the backup run (the saved data is what matters).
+    # ponytail: unconditional; add a settings.ini toggle only if someone asks.
+    try:
+        import generate_index
+        generate_index.main([save_directory])
+    except Exception as e:
+        print(f"Index generation skipped: {e}")
 
 if __name__ == "__main__":
     main()

--- a/settings.ini
+++ b/settings.ini
@@ -11,6 +11,9 @@ ignore_tls_errors = false
 [Configuration]
 client_id = None
 client_secret = None
+# Preferred: set refresh_token (mint once via: python get_refresh_token.py) and
+# leave username/password as None. Falls back to username+password when unset.
+refresh_token = None
 username = None
 password = None
 

--- a/tests/test_early_stop.py
+++ b/tests/test_early_stop.py
@@ -1,0 +1,78 @@
+"""Tests for incremental-fetch early stop (_collect_until_known).
+
+The risk this guards: a naive "stop at the first already-saved item" drops new
+items, because a re-saved/re-voted OLD item jumps to the front of a newest-first
+listing and can sit ahead of a genuinely new save. The streak-based stop must
+not drop that new item, and must still stop once past the recently-touched region.
+"""
+import types
+import unittest
+
+from utils.file_operations import _collect_until_known
+from utils.constants import EARLY_STOP_KNOWN_STREAK
+
+
+# Class names matter: _collect_until_known keys off type(item).__name__.
+class Submission:
+    def __init__(self, id_, sub="test"):
+        self.id = id_
+        self.subreddit = types.SimpleNamespace(display_name=sub)
+
+
+CATEGORY_MAP = {"Submission": "SAVED_POST"}
+
+
+def _key(item):
+    # Must match the unique_key format in save_to_file().
+    return f"{item.id}-{item.subreddit.display_name}-Submission-SAVED_POST"
+
+
+def _counting_iter(items, consumed):
+    for it in items:
+        consumed.append(it.id)
+        yield it
+
+
+class TestEarlyStop(unittest.TestCase):
+    def test_stops_after_known_streak_and_skips_rest(self):
+        new = [Submission("new")]
+        known = [Submission(f"k{i}") for i in range(EARLY_STOP_KNOWN_STREAK)]
+        tail = [Submission(f"t{i}") for i in range(10)]  # must NOT be fetched
+        existing = {_key(k) for k in known + tail}
+
+        consumed = []
+        result = _collect_until_known(_counting_iter(new + known + tail, consumed),
+                                      existing, CATEGORY_MAP)
+
+        # Consumed exactly the new item + the streak, then broke.
+        self.assertEqual(len(result), 1 + EARLY_STOP_KNOWN_STREAK)
+        for t in tail:
+            self.assertNotIn(t.id, consumed)  # later pages were never fetched
+
+    def test_interleaved_new_item_is_not_dropped(self):
+        # [re-saved old (known), NEW, then a long known streak].
+        resaved = Submission("old_resaved")
+        new = Submission("brand_new")
+        known = [Submission(f"k{i}") for i in range(EARLY_STOP_KNOWN_STREAK)]
+        existing = {_key(resaved)} | {_key(k) for k in known}
+
+        result = _collect_until_known(iter([resaved, new] + known), existing, CATEGORY_MAP)
+        ids = [it.id for it in result]
+
+        self.assertIn("brand_new", ids)   # the regression this whole design exists to prevent
+
+    def test_no_context_returns_full_listing(self):
+        items = [Submission(f"s{i}") for i in range(5)]
+        self.assertEqual(_collect_until_known(iter(items), set(), CATEGORY_MAP), items)
+        self.assertEqual(_collect_until_known(iter(items), {"x"}, None), items)
+
+    def test_all_new_consumes_everything(self):
+        items = [Submission(f"s{i}") for i in range(150)]
+        consumed = []
+        result = _collect_until_known(_counting_iter(items, consumed), {"nothing"}, CATEGORY_MAP)
+        self.assertEqual(len(result), 150)
+        self.assertEqual(len(consumed), 150)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/utils/config_validator.py
+++ b/utils/config_validator.py
@@ -130,7 +130,7 @@ class ConfigValidator:
         # Note: We don't validate Reddit credentials here since env_config.py handles that
         # with proper environment variable fallbacks. Just check format.
 
-        config_keys = ['client_id', 'client_secret', 'username', 'password']
+        config_keys = ['client_id', 'client_secret', 'username', 'password', 'refresh_token']
         for key in config_keys:
             value = self.config_parser.get('Configuration', key, fallback=None)
             if value and value.isspace():

--- a/utils/constants.py
+++ b/utils/constants.py
@@ -93,6 +93,15 @@ VALID_AUDIO_EXTENSIONS = {
     '.mp3', '.m4a', '.wav', '.ogg', '.flac'
 }
 
+# Incremental Fetch
+# Reddit listings are newest-first, so new items cluster at the front. During a
+# fetch we stop paginating once we have seen this many CONSECUTIVE already-saved
+# items. A streak that long means we are past the recently-touched region; the
+# rest of the listing is older and already backed up. This is intentionally
+# larger than Reddit's 100-item page so a handful of re-saved/re-voted old items
+# (which jump to the front) can never hide a genuinely new item behind them.
+EARLY_STOP_KNOWN_STREAK = 100
+
 # User Agent
 DEFAULT_USER_AGENT = "Reddit Stash Media Downloader/1.0"
 CHROME_USER_AGENT = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36"

--- a/utils/env_config.py
+++ b/utils/env_config.py
@@ -16,43 +16,47 @@ def load_config_and_env():
     # Read the settings.ini file
     config_parser.read(config_file_path)
 
-    # Load from settings.ini, but treat "None" or empty strings as invalid
-    client_id = config_parser.get('Configuration', 'client_id', fallback=None)
-    client_secret = config_parser.get('Configuration', 'client_secret', fallback=None)
-    username = config_parser.get('Configuration', 'username', fallback=None)
-    password = config_parser.get('Configuration', 'password', fallback=None)
+    # Load from settings.ini, falling back to env vars; treat "None"/empty as unset.
+    def _load(key, env):
+        value = config_parser.get('Configuration', key, fallback=None)
+        return value if value and value not in invalid_config else os.getenv(env)
 
-    # If the values from the config are "None" (as strings) or empty, fallback to environment variables
-    client_id = client_id if client_id and client_id not in invalid_config else os.getenv('REDDIT_CLIENT_ID')
-    client_secret = client_secret if client_secret and client_secret not in invalid_config else os.getenv('REDDIT_CLIENT_SECRET')
-    username = username if username and username not in invalid_config else os.getenv('REDDIT_USERNAME')
-    password = password if password and password not in invalid_config else os.getenv('REDDIT_PASSWORD')
+    client_id = _load('client_id', 'REDDIT_CLIENT_ID')
+    client_secret = _load('client_secret', 'REDDIT_CLIENT_SECRET')
+    username = _load('username', 'REDDIT_USERNAME')
+    password = _load('password', 'REDDIT_PASSWORD')
+    refresh_token = _load('refresh_token', 'REDDIT_REFRESH_TOKEN')
 
-    # Check if any required credentials are still missing
-    if not all([client_id, client_secret, username, password]):
+    # Two auth modes: a refresh_token (preferred - no password in secrets, survives)
+    # OR username+password. client_id/client_secret are required either way.
+    have_token_auth = all([client_id, client_secret, refresh_token])
+    have_password_auth = all([client_id, client_secret, username, password])
+
+    if not (have_token_auth or have_password_auth):
         missing = []
         if not client_id:
             missing.append("REDDIT_CLIENT_ID")
         if not client_secret:
             missing.append("REDDIT_CLIENT_SECRET")
-        if not username:
-            missing.append("REDDIT_USERNAME")
-        if not password:
-            missing.append("REDDIT_PASSWORD")
+        if not refresh_token and not (username and password):
+            missing.append("REDDIT_REFRESH_TOKEN (or REDDIT_USERNAME + REDDIT_PASSWORD)")
 
         msg = (
             f"Missing Reddit API credentials: {', '.join(missing)}\n\n"
             "Since November 2025, Reddit requires pre-approval to create new API apps.\n"
             "If you need new credentials, apply here (2-4 week wait):\n"
             "  https://support.reddithelp.com/hc/en-us/requests/new?ticket_form_id=14868593862164\n\n"
-            "Existing credentials (created before Nov 2025) still work normally.\n"
-            "Set credentials via environment variables (REDDIT_CLIENT_ID, etc.) or in settings.ini.\n\n"
+            "Existing credentials (created before Nov 2025) still work normally.\n\n"
+            "Auth options:\n"
+            "  1. REDDIT_REFRESH_TOKEN (preferred) - run get_refresh_token.py once to mint it.\n"
+            "  2. REDDIT_USERNAME + REDDIT_PASSWORD.\n"
+            "Set credentials via environment variables or in settings.ini.\n\n"
             "Alternative: Set process_api=false and process_gdpr=true in settings.ini\n"
             "to process your Reddit GDPR export data without API credentials."
         )
         raise Exception(msg)
 
-    return client_id, client_secret, username, password
+    return client_id, client_secret, username, password, refresh_token
 
 def get_ignore_tls_errors():
     """Load the ignore_tls_errors setting from settings.ini."""

--- a/utils/file_operations.py
+++ b/utils/file_operations.py
@@ -12,6 +12,7 @@ from utils.time_utilities import dynamic_sleep
 from utils.env_config import get_ignore_tls_errors
 from utils.path_security import create_safe_path, create_reddit_file_path
 from utils.praw_helpers import safe_fetch_items_one_by_one
+from utils.constants import EARLY_STOP_KNOWN_STREAK
 
 
 logger = logging.getLogger(__name__)
@@ -187,19 +188,73 @@ def _clone_reddit(reddit):
     Each thread needs its own instance with separate OAuth token and rate limit budget.
     """
     import praw
-    return praw.Reddit(
-        client_id=reddit.config.client_id,
-        client_secret=reddit.config.client_secret,
-        username=reddit.config.username,
-        password=reddit.config.password,
-        user_agent=reddit.config.user_agent,
-    )
+    kwargs = {
+        'client_id': reddit.config.client_id,
+        'client_secret': reddit.config.client_secret,
+        'user_agent': reddit.config.user_agent,
+    }
+    refresh_token = getattr(reddit.config, 'refresh_token', None)
+    if refresh_token:
+        kwargs['refresh_token'] = refresh_token
+    else:
+        kwargs['username'] = reddit.config.username
+        kwargs['password'] = reddit.config.password
+    return praw.Reddit(**kwargs)
 
 
-def _fetch_items(reddit_instance, fetch_method_name, limit, label):
+# Maps each fetch endpoint's returned item types to the unique-key category used
+# when saving, so incremental fetch can recognize already-saved items. Must stay
+# in sync with the category / sub_category / comment_category values passed to the
+# processors in save_user_activity below.
+_FETCH_CATEGORY_MAPS = {
+    'submission': {'Submission': 'POST'},
+    'comment': {'Comment': 'COMMENT'},
+    'saved': {'Submission': 'SAVED_POST', 'Comment': 'SAVED_COMMENT'},
+    'upvoted': {'Submission': 'UPVOTE_POST', 'Comment': 'UPVOTE_COMMENT'},
+}
+
+
+def _collect_until_known(items_iter, existing_files, category_map):
+    """Materialize a PRAW listing, stopping early once we are past the new items.
+
+    Listings are newest-first, so genuinely new items sit at the front. Once we
+    have seen EARLY_STOP_KNOWN_STREAK consecutive items already in existing_files
+    we are safely past the recently-touched region and can skip fetching the
+    remaining (older, already-saved) pages. Without dedup context we fall back to
+    consuming the whole listing, preserving the previous behaviour.
+    """
+    if not existing_files or not category_map:
+        return list(items_iter)
+
+    items = []
+    known_streak = 0
+    for item in items_iter:
+        items.append(item)
+        category = category_map.get(type(item).__name__)
+        if category is None:
+            known_streak = 0
+            continue
+        try:
+            unique_key = f"{item.id}-{item.subreddit.display_name}-{type(item).__name__}-{category}"
+        except Exception:
+            known_streak = 0  # can't judge this item; keep fetching to stay safe
+            continue
+        if unique_key in existing_files:
+            known_streak += 1
+            if known_streak >= EARLY_STOP_KNOWN_STREAK:
+                break
+        else:
+            known_streak = 0
+    return items
+
+
+def _fetch_items(reddit_instance, fetch_method_name, limit, label,
+                 existing_files=None, category_map=None):
     """Fetch items from a PRAW user endpoint with batch-then-one-by-one fallback.
 
-    Uses its own PRAW instance for thread-safe parallel fetching.
+    Uses its own PRAW instance for thread-safe parallel fetching. When
+    existing_files and category_map are provided, stops paginating early once it
+    passes the already-saved items (see _collect_until_known).
     """
     user = reddit_instance.user.me()
     if fetch_method_name in ('submissions', 'comments'):
@@ -209,7 +264,7 @@ def _fetch_items(reddit_instance, fetch_method_name, limit, label):
         items_iter = getattr(user, fetch_method_name)(limit=limit)
 
     try:
-        return list(items_iter)
+        return _collect_until_known(items_iter, existing_files, category_map)
     except prawcore.exceptions.NotFound:
         logger.warning(f"Batch fetch of {label} failed with 404, using safe iteration")
         if fetch_method_name in ('submissions', 'comments'):
@@ -408,7 +463,8 @@ def save_user_activity(reddit, save_directory, file_log, unsave=False):
             futures = {}
             for method, label in endpoints:
                 r = _clone_reddit(reddit)
-                futures[label] = pool.submit(_fetch_items, r, method, 1000, label)
+                futures[label] = pool.submit(_fetch_items, r, method, 1000, label,
+                                             existing_files, _FETCH_CATEGORY_MAPS[label])
             for label, future in futures.items():
                 fetched[label] = future.result()
 
@@ -449,8 +505,10 @@ def save_user_activity(reddit, save_directory, file_log, unsave=False):
         with ThreadPoolExecutor(max_workers=2) as pool:
             r1 = _clone_reddit(reddit)
             r2 = _clone_reddit(reddit)
-            f_sub = pool.submit(_fetch_items, r1, 'submissions', 1000, 'submission')
-            f_com = pool.submit(_fetch_items, r2, 'comments', 1000, 'comment')
+            f_sub = pool.submit(_fetch_items, r1, 'submissions', 1000, 'submission',
+                                existing_files, _FETCH_CATEGORY_MAPS['submission'])
+            f_com = pool.submit(_fetch_items, r2, 'comments', 1000, 'comment',
+                                existing_files, _FETCH_CATEGORY_MAPS['comment'])
             submissions = f_sub.result()
             comments = f_com.result()
 
@@ -469,14 +527,16 @@ def save_user_activity(reddit, save_directory, file_log, unsave=False):
             )
 
     elif save_type == 'SAVED':
-        saved_items = _fetch_items(reddit, 'saved', 1000, 'saved')
+        saved_items = _fetch_items(reddit, 'saved', 1000, 'saved',
+                                   existing_files, _FETCH_CATEGORY_MAPS['saved'])
         processed_count, skipped_count, total_size, total_media_size = _process_mixed_items(
             saved_items, sub_category="SAVED_POST", comment_category="SAVED_COMMENT",
             unsave=unsave, tqdm_desc="Saved Items", **shared_args
         )
 
     elif save_type == 'UPVOTED':
-        upvoted_items = _fetch_items(reddit, 'upvoted', 1000, 'upvoted')
+        upvoted_items = _fetch_items(reddit, 'upvoted', 1000, 'upvoted',
+                                     existing_files, _FETCH_CATEGORY_MAPS['upvoted'])
         processed_count, skipped_count, total_size, total_media_size = _process_mixed_items(
             upvoted_items, sub_category="UPVOTE_POST", comment_category="UPVOTE_COMMENT",
             tqdm_desc="Upvoted Items", **shared_args


### PR DESCRIPTION
## What this does for users

Three quality-of-life improvements to Reddit Stash:

1. Back up without putting your Reddit password in CI secrets. You can now authenticate with a long-lived refresh token instead of username + password. Password auth still works as a fallback.
2. Faster incremental runs. The fetch stops paginating once it is past the newly-saved items, instead of pulling every page on every run.
3. Find things in your backup. Each run now writes a self-contained, searchable index.html over the saved markdown, so you can filter by title, subreddit, or author instead of grepping folders.

## Auth (refresh token)

- Prefers `REDDIT_REFRESH_TOKEN` when set, falls back to `REDDIT_USERNAME` + `REDDIT_PASSWORD` otherwise (client_id / client_secret required either way).
- New one-time helper `get_refresh_token.py` mints the token via PRAW's OAuth flow (needs a "web app" type Reddit app).
- Uses PRAW's native `refresh_token` support, so there is no custom OAuth code. The thread-local client clone mirrors the same auth mode.
- Note: this does not bypass Reddit's November 2025 app-approval requirement. It is a security and UX upgrade for users who already have credentials.

## Incremental fetch

- Listings are newest-first, so new items cluster at the front. The fetch now stops after `EARLY_STOP_KNOWN_STREAK` (100) consecutive already-saved items, skipping the remaining older pages.
- The 100-item streak (larger than Reddit's 100-item page) is deliberate. A few re-saved or re-voted old items jump to the front of the listing, and stopping at the very first known item would drop a genuinely new item sitting behind them. Without dedup context it falls back to reading the full listing.

## Searchable index

- `generate_index.py` walks the save directory, reads the YAML front matter each markdown file already carries, and writes `index.html` with a client-side filter box. No new dependency, no server.
- Runs automatically at the end of each backup (best-effort, it never fails the run) and can also be run standalone.
- Content is rendered via `textContent` with `</script>` escaping, so archived Reddit content cannot inject markup.

## Tests

- `tests/test_early_stop.py` covers the streak-based stop and the interleaved-new-item regression (force-added, since `tests/` is gitignored in this repo).
- Both new scripts have a `--selftest`. `ruff` is clean across all changed files.

## Files changed

`utils/env_config.py`, `reddit_stash.py`, `utils/file_operations.py`, `utils/config_validator.py`, `utils/constants.py`, `.env.example`, `settings.ini`, plus new `generate_index.py`, `get_refresh_token.py`, `tests/test_early_stop.py`.