### PR TITLE
Drop pandas: read GDPR CSVs with the stdlib csv module

### DIFF
--- a/.github/workflows/python-compatibility.yml
+++ b/.github/workflows/python-compatibility.yml
@@ -58,7 +58,6 @@ jobs:
           # Test that all core modules can be imported
           python -c "import praw; print(f'PRAW version: {praw.__version__}')"
           python -c "import dropbox; print('Dropbox SDK imported successfully')"
-          python -c "import pandas; print(f'Pandas version: {pandas.__version__}')"
           python -c "import tqdm; print(f'tqdm version: {tqdm.__version__}')"
           python -c "import requests; print(f'Requests version: {requests.__version__}')"
 

--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -4,7 +4,6 @@
 # Core dependencies - required for basic functionality
 praw>=8.0.0,<9.0.0          # Reddit API wrapper
 dropbox>=12.1.0             # Dropbox API client
-pandas>=3.0.0,<4.0.0        # Data manipulation
 tqdm>=4.68.4                # Progress bars
 requests>=2.34.2            # HTTP library (fallback for curl-cffi)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 # Core Reddit Stash dependencies (Updated Jul 2026)
 praw>=8.0.0,<9.0.0          # Reddit API wrapper
 dropbox>=12.1.0             # Dropbox API client
-pandas>=3.0.0,<4.0.0        # Data manipulation
 tqdm>=4.68.4                # Progress bars
 requests>=2.34.2            # HTTP library
 

--- a/tests/test_gdpr_processor.py
+++ b/tests/test_gdpr_processor.py
@@ -99,6 +99,32 @@ class TestGdprExportProcessing(unittest.TestCase):
         reddit.info.assert_called_once_with(fullnames=['t3_post123', 't3_post456'])
         reddit.submission.assert_not_called()
 
+    def test_archive_id_treats_missing_values_as_empty(self):
+        # With pandas removed, empty CSV cells arrive as '' (not NaN); _archive_id
+        # must still normalize missing ids to '' and strip the t1_/t3_ prefixes.
+        from utils.gdpr_processor import _archive_id
+        self.assertEqual(_archive_id(''), '')
+        self.assertEqual(_archive_id(None), '')
+        self.assertEqual(_archive_id('   '), '')
+        self.assertEqual(_archive_id('t3_abc123'), 'abc123')
+        self.assertEqual(_archive_id('t1_def456'), 'def456')
+        self.assertEqual(_archive_id('ghi789'), 'ghi789')
+
+    def test_read_csv_rows_returns_empty_string_for_missing_cells(self):
+        # A row with an empty id must read back as '' rather than raising or
+        # producing a NaN float, so downstream null checks keep working.
+        from utils.gdpr_processor import _archive_id, _read_csv_rows
+        path = self.gdpr_directory / 'saved_posts.csv'
+        with path.open('w', newline='', encoding='utf-8') as export_file:
+            export_file.write('id,permalink\n')
+            export_file.write('post123,/r/test/comments/post123/\n')
+            export_file.write(',\n')
+        rows = _read_csv_rows(str(path))
+        self.assertEqual(len(rows), 2)
+        self.assertEqual(rows[0]['id'], 'post123')
+        self.assertEqual(rows[1]['id'], '')
+        self.assertEqual(_archive_id(rows[1]['id']), '')
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/utils/gdpr_processor.py
+++ b/utils/gdpr_processor.py
@@ -1,7 +1,7 @@
 import os
 import json
+import csv
 import logging
-import pandas as pd
 from tqdm import tqdm
 from utils.file_operations import save_to_file
 from utils.save_utils import save_submission, save_comment_and_context
@@ -24,6 +24,16 @@ def get_gdpr_directory(save_directory):
     if not os.path.exists(gdpr_dir):
         print(f"GDPR data directory not found at: {gdpr_dir}")
     return gdpr_dir
+
+
+def _read_csv_rows(path):
+    """Read a GDPR export CSV into a list of row dicts using the stdlib csv module.
+
+    Uses utf-8-sig so a byte-order mark (which pandas stripped automatically) does not
+    leak into the first column name. Empty cells arrive as '' rather than a NaN float.
+    """
+    with open(path, newline='', encoding='utf-8-sig') as handle:
+        return list(csv.DictReader(handle))
 
 
 def _save_csv_only_post(
@@ -265,7 +275,7 @@ def _yaml_frontmatter(fields):
 
 def _archive_id(item_id):
     """Normalize a Reddit fullname to the base36 ID used in archive responses."""
-    if pd.isna(item_id):
+    if item_id is None or str(item_id).strip() == '':
         return ''
     normalized_id = str(item_id).strip()
     return normalized_id[3:] if normalized_id.startswith(('t1_', 't3_')) else normalized_id
@@ -359,14 +369,15 @@ def process_gdpr_export(
     posts_file = os.path.join(gdpr_dir, 'saved_posts.csv')
     if os.path.exists(posts_file):
         print("\nProcessing saved posts from GDPR export...")
-        df = pd.read_csv(posts_file)
+        rows = _read_csv_rows(posts_file)
+        ids = [row.get('id', '') for row in rows]
         archived_posts = (
-            _fetch_from_archive(df['id'].tolist(), 'posts', archive_client, archive_fallback)
+            _fetch_from_archive(ids, 'posts', archive_client, archive_fallback)
             if csv_only_mode else {}
         )
-        reddit_posts = _fetch_reddit_items(reddit, df['id'].tolist(), 't3') if not csv_only_mode else {}
+        reddit_posts = _fetch_reddit_items(reddit, ids, 't3') if not csv_only_mode else {}
 
-        for _, row in tqdm(df.iterrows(), total=len(df), desc="Processing GDPR Posts"):
+        for row in tqdm(rows, total=len(rows), desc="Processing GDPR Posts"):
             try:
                 if csv_only_mode:
                     count, size = _save_csv_only_post(
@@ -423,14 +434,15 @@ def process_gdpr_export(
     comments_file = os.path.join(gdpr_dir, 'saved_comments.csv')
     if os.path.exists(comments_file):
         print("\nProcessing saved comments from GDPR export...")
-        df = pd.read_csv(comments_file)
+        rows = _read_csv_rows(comments_file)
+        ids = [row.get('id', '') for row in rows]
         archived_comments = (
-            _fetch_from_archive(df['id'].tolist(), 'comments', archive_client, archive_fallback)
+            _fetch_from_archive(ids, 'comments', archive_client, archive_fallback)
             if csv_only_mode else {}
         )
-        reddit_comments = _fetch_reddit_items(reddit, df['id'].tolist(), 't1') if not csv_only_mode else {}
+        reddit_comments = _fetch_reddit_items(reddit, ids, 't1') if not csv_only_mode else {}
 
-        for _, row in tqdm(df.iterrows(), total=len(df), desc="Processing GDPR Comments"):
+        for row in tqdm(rows, total=len(rows), desc="Processing GDPR Comments"):
             try:
                 if csv_only_mode:
                     count, size = _save_csv_only_comment(


### PR DESCRIPTION
## What this does

Removes pandas from reddit-stash. It was used in only one file
(`utils/gdpr_processor.py`) to read the two GDPR export CSVs and for a single null
check, so it is replaced with the stdlib `csv` module.

## Why

- **Faster startup**: `import pandas` (which pulls in numpy, plus pyarrow on pandas 3) cost
  roughly 0.3 to 1s, and `gdpr_processor` is imported on the normal run path. `csv` is stdlib
  and free.
- **Smaller install and Docker image**: drops pandas + numpy (and pyarrow).
- **Removes the pandas version-migration surface** entirely (no more pandas 2-vs-3 concerns).

## Changes

- `gdpr_processor.py`: `pd.read_csv` becomes `csv.DictReader` (new `_read_csv_rows` helper),
  `df.iterrows()` becomes plain row iteration, and the `pd.isna` id check becomes a plain
  empty-string / None check.
- Empty CSV cells now read as `''` rather than a NaN float, so `_archive_id` treats empty and
  whitespace-only ids as missing. Two new tests lock this behavior (including an empty-id row).
- pandas removed from `requirements.txt`, `requirements-minimal.txt`, and the CI import check.

No behavior change for valid exports. The full test suite (265 tests) and ruff pass. The row
consumers only ever used `row['id']` and `row.get('permalink', '')`, both of which work
unchanged on `csv.DictReader` dicts.
