### PR TITLE
Restore Python 3.10 support (pandas is gone)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -28,7 +28,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/python-compatibility.yml
+++ b/.github/workflows/python-compatibility.yml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
       max-parallel: 3
       matrix:
-        python-version: ["3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - name: Checkout repository

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use a slim Python base image for smaller size
-# Supports Python 3.11 through 3.13 (default: 3.12)
+# Supports Python 3.10 through 3.13 (default: 3.12)
 ARG PYTHON_VERSION=3.12
 FROM python:${PYTHON_VERSION}-slim
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Reddit Stash: Automatically Save Reddit Posts and Comments to Local, Dropbox, or S3
 
-[![Python](https://img.shields.io/badge/Python-3.11--3.13-blue.svg?style=for-the-badge&logo=python&logoColor=white)](https://www.python.org/)
+[![Python](https://img.shields.io/badge/Python-3.10--3.13-blue.svg?style=for-the-badge&logo=python&logoColor=white)](https://www.python.org/)
 [![GitHub Actions](https://img.shields.io/badge/GitHub_Actions-Workflow-2088FF?style=for-the-badge&logo=github-actions&logoColor=white)](https://github.com/features/actions)
 [![Docker](https://img.shields.io/badge/Docker-Available-2496ED?style=for-the-badge&logo=docker&logoColor=white)](https://github.com/rhnfzl/reddit-stash/pkgs/container/reddit-stash)
 [![Dropbox](https://img.shields.io/badge/Dropbox-Integration-0061FF?style=for-the-badge&logo=dropbox&logoColor=white)](https://www.dropbox.com/)
@@ -197,7 +197,7 @@ For detailed setup instructions, continue reading the [Setup](#setup) section.
 |---------|---------------|-------------------|--------|
 | **Ease of Setup** | ⭐⭐⭐ (Easiest) | ⭐⭐ | ⭐⭐ |
 | **Automation** | ✅ Runs on schedule | ✅ Manual control or cron | ✅ Built-in scheduling support |
-| **Requirements** | GitHub account | Python 3.11-3.13 | Docker |
+| **Requirements** | GitHub account | Python 3.10-3.13 | Docker |
 | **Data Storage** | Dropbox or S3 | Local, Dropbox, or S3 | Local, Dropbox, or S3 |
 | **Maintenance** | Minimal | More hands-on | Low to Medium |
 | **Privacy** | Credentials in GitHub secrets | Credentials on local machine | Credentials in container |
@@ -240,7 +240,7 @@ Beyond text, Reddit Stash can download and preserve images, videos, and other me
 ## Setup
 
 ### Prerequisites
-- ✅ Python 3.11-3.13 (Python 3.13 recommended for best performance)
+- ✅ Python 3.10-3.13 (Python 3.13 recommended for best performance)
 - 🔑 Reddit API credentials
 - 📊 A cloud storage account (optional): Dropbox with API token, or an AWS account with S3 access
 
@@ -286,7 +286,7 @@ After adding all secrets: ![Repository Secrets](resources/repository_secrets.png
    - You can adjust these times in the workflow file to match your timezone if needed.
 
 5. **Additional Workflows**: The repository includes automated workflows for maintenance and testing:
-   - `python-compatibility.yml`: Tests compatibility across Python versions 3.11-3.13
+   - `python-compatibility.yml`: Tests compatibility across Python versions 3.10-3.13
 
 #### Local Installation
 
@@ -435,7 +435,7 @@ docker run -d \
 |-----|-------------|----------|
 | `latest` | Latest stable from main branch | Production deployments |
 | `develop` | Development version | Testing new features |
-| `py3.11-latest`, `py3.12-latest`, `py3.13-latest` | Python-specific versions | Specific Python requirements |
+| `py3.10-latest`, `py3.11-latest`, `py3.12-latest`, `py3.13-latest` | Python-specific versions | Specific Python requirements |
 | `v1.0.0` | Semantic version tags | Version pinning |
 | `sha-abc123` | Commit-specific builds | Reproducible deployments |
 
@@ -1058,7 +1058,7 @@ docker run -d \
 
 #### Docker Notes:
 
-- **Python Support**: Build supports Python 3.11 through 3.13 (3.12 is default)
+- **Python Support**: Build supports Python 3.10 through 3.13 (3.12 is default)
 - **Security**: The container runs as a non-root user for security
 - **Data Persistence**: Data is persisted through a volume mount (`-v $(pwd)/reddit:/app/reddit`) to your local machine
 - **Runtime Configuration**: Environment variables must be provided at runtime
@@ -1145,7 +1145,7 @@ After completing your chosen installation method, verify that everything is work
 - [ ] Content files are present and readable
 
 #### For Local Installation:
-- [ ] Python 3.11-3.13 installed and working (3.13 recommended)
+- [ ] Python 3.10-3.13 installed and working (3.13 recommended)
 - [ ] Repository cloned successfully
 - [ ] Dependencies installed via `pip install -r requirements.txt`
 - [ ] Environment variables set correctly


### PR DESCRIPTION
## What this does

Restores Python 3.10 support. pandas 3 required Python 3.11+, which was the only reason 3.10
was dropped. With pandas removed (#25), praw 8 and every other dependency support 3.10 again.

## Changes

- CI matrix in both workflows (`python-compatibility` and `docker-publish`): add `3.10` back, so
  the suite and image build run on 3.10, 3.11, 3.12, 3.13.
- Dockerfile comment and all README references updated to "3.10 through 3.13".

No application code changes. The 3.10 CI job validates that the current code still runs on 3.10
(it already passed on 3.10 before the temporary drop). The `python-compatibility (3.10)` check is
also added to the required set in branch protection, so this is genuinely gated.
