### PR TITLE
Remove five unused/redundant dependencies

### DIFF
--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -10,10 +10,8 @@ requests>=2.34.2            # HTTP library (fallback for curl-cffi)
 # Essential media download dependencies
 urllib3>=2.7.0              # HTTP connection pooling
 tenacity>=9.1.4             # Intelligent retry strategies
-backoff>=2.2.1              # Exponential backoff with jitter
 
-# Configuration and validation
-configparser>=7.2.0         # Configuration parsing
+# File integrity
 blake3>=1.0.9                # Fast cryptographic hashing
 
 # Basic media processing

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,17 +8,12 @@ requests>=2.34.2            # HTTP library
 urllib3>=2.7.0              # HTTP connection pooling
 curl-cffi>=0.13.0            # HTTP/2 + browser TLS fingerprinting
 tenacity>=9.1.4             # Intelligent retry strategies
-backoff>=2.2.1              # Exponential backoff with jitter for rate limiting
 
-# Enhanced configuration and validation
-configparser>=7.2.0         # Configuration parsing
+# File integrity
 blake3>=1.0.9                # Fast cryptographic hashing for file integrity
 
 # Optional media processing dependencies
 pillow>=11.3.0              # Image processing
-requests-cache>=1.3.3       # HTTP request caching
-beautifulsoup4>=4.15.0      # HTML parsing
-html5lib>=1.1               # HTML5 parser for BeautifulSoup
 
 # Note: All other dependencies (threading, sqlite3, json, logging, etc.)
 # are part of Python standard library and don't need to be listed here

--- a/utils/config_validator.py
+++ b/utils/config_validator.py
@@ -154,9 +154,6 @@ class ConfigValidator:
         """Check if required dependencies are available for media features."""
         optional_imports = {
             'PIL': 'pillow',
-            'requests_cache': 'requests-cache',
-            'bs4': 'beautifulsoup4',
-            'html5lib': 'html5lib'
         }
         missing_deps = []
         for module, package in optional_imports.items():


### PR DESCRIPTION
## What this does

Removes five dependencies that are unused or redundant, verified by auditing every import
site in the codebase.

## Removed

- **configparser**: it is a stdlib module on Python 3; the PyPI package is a Python 2 backport,
  so `import configparser` uses the stdlib regardless.
- **backoff**: never imported. The project has its own retry/backoff logic (`rate_limiter.py`
  and the `EXPONENTIAL_BACKOFF_*` constants); the "backoff" matches in the tree are all that
  code, not the library.
- **beautifulsoup4**, **html5lib**, **requests-cache**: only referenced in a stale
  optional-dependency check in `config_validator`; nothing imports or uses them. Those three
  entries are also removed from `_check_media_dependencies()` so it no longer warns users to
  install packages the app never touches.

## Kept (all genuinely used)

praw, requests, urllib3 (Retry + warning suppression), curl-cffi (HTTP/2 fingerprinting),
tenacity (the retry library actually used), blake3 (content hashing), tqdm (progress bars),
dropbox (sync), and pillow (`base_downloader` uses `Image.open` to validate downloaded images).

## Impact

Smaller install and Docker image: requests-cache alone pulled cattrs, url-normalize,
platformdirs, and attrs; beautifulsoup4 pulled soupsieve; html5lib pulled webencodings and six.
No behavior change. The full test suite (265 tests) and ruff pass.
